### PR TITLE
Remove branching at decode

### DIFF
--- a/src/Data/ByteString/Base64/Internal.hs
+++ b/src/Data/ByteString/Base64/Internal.hs
@@ -28,7 +28,6 @@ import Foreign.ForeignPtr
 import Foreign.Ptr
 import Foreign.Storable
 
-import GHC.Word
 
 -- | Given a bytestring, check to see that it conforms to a given alphabet
 --

--- a/src/Data/ByteString/Base64/Internal/Head.hs
+++ b/src/Data/ByteString/Base64/Internal/Head.hs
@@ -107,6 +107,7 @@ decodeBase64_ !dlen !dtfp (PS !sfp !soff !slen') =
           (castPtr (plusPtr sptr (soff + slen')))
           dfp
           0
+{-# INLINE decodeBase64_ #-}
 
 decodeBase64Lenient_ :: ForeignPtr Word8 -> ByteString -> ByteString
 decodeBase64Lenient_ !dtfp (PS !sfp !soff !slen) = unsafeDupablePerformIO $

--- a/src/Data/ByteString/Base64/Internal/Tail.hs
+++ b/src/Data/ByteString/Base64/Internal/Tail.hs
@@ -68,12 +68,6 @@ loopTail !dfp (Ptr !alpha) !end !src !dst !n
       poke @Word8 (plusPtr dst 2) (aix d alpha)
       poke @Word8 (plusPtr dst 3) 0x3d
       return (PS dfp 0 (n + 4))
-
-
-
-
-
-
 {-# INLINE loopTail #-}
 
 

--- a/src/Data/ByteString/Base64/Internal/Utils.hs
+++ b/src/Data/ByteString/Base64/Internal/Utils.hs
@@ -13,7 +13,6 @@
 --
 module Data.ByteString.Base64.Internal.Utils
 ( EncodingTable(..)
-, Padding(..)
 , aix
 , packTable
 , w32
@@ -41,19 +40,6 @@ import GHC.Word
 data EncodingTable = EncodingTable
   {-# UNPACK #-} !(Ptr Word8)
   {-# UNPACK #-} !(ForeignPtr Word16)
-
-
--- | A type isomorphic to 'Bool' marking support for padding out bytestrings (@Pad),
--- or not (@Nopad@).
---
-data Padding
-    = Padded
-      -- ^ Do we require padding?
-    | Unpadded
-      -- ^ Do we not require padding? If so, check against padding char
-    | Don'tCare
-      -- ^ Do we not care? (should we pad if it needs it?)
-    deriving Eq
 
 -- | Read 'Word8' index off alphabet addr
 --

--- a/src/Data/ByteString/Base64/Internal/W16/Loop.hs
+++ b/src/Data/ByteString/Base64/Internal/W16/Loop.hs
@@ -64,6 +64,7 @@ innerLoop !etable !sptr !dptr !end finish !nn = go sptr dptr nn
         poke (plusPtr dst 2) y
 
         go (plusPtr src 3) (plusPtr dst 4) (n + 4)
+{-# INLINE innerLoop #-}
 
 decodeLoop
     :: Ptr Word8
@@ -89,7 +90,7 @@ decodeLoop !dtable !sptr !dptr !end !dfp !nn = go dptr sptr nn
       ++ show (p `minusPtr` sptr)
 
     look :: Ptr Word8 -> IO Word32
-    look p = do
+    look !p = do
       !i <- peekByteOff @Word8 p 0
       !v <- peekByteOff @Word8 dtable (fromIntegral i)
       return (fromIntegral v)
@@ -97,10 +98,10 @@ decodeLoop !dtable !sptr !dptr !end !dfp !nn = go dptr sptr nn
     go !dst !src !n
       | src >= end = return (Right (PS dfp 0 n))
       | otherwise = do
-        a <- look src
-        b <- look (src `plusPtr` 1)
-        c <- look (src `plusPtr` 2)
-        d <- look (src `plusPtr` 3)
+        !a <- look src
+        !b <- look (src `plusPtr` 1)
+        !c <- look (src `plusPtr` 2)
+        !d <- look (src `plusPtr` 3)
 
         if
           | a == 0x63 -> padErr src
@@ -146,7 +147,7 @@ lenientLoop !dtable !sptr !dptr !end !dfp = go dptr sptr 0
     finalize !n = return (PS dfp 0 n)
     {-# INLINE finalize #-}
 
-    look skip !p_ f = k p_
+    look !skip !p_ f = k p_
       where
         k !p
           | p >= end = f (plusPtr end (-1)) (0x63 :: Word32)

--- a/src/Data/ByteString/Base64/URL.hs
+++ b/src/Data/ByteString/Base64/URL.hs
@@ -74,9 +74,9 @@ decodeBase64 bs@(PS _ _ !l)
     | r == 0 = unsafeDupablePerformIO $
       decodeBase64_ dlen decodeB64UrlTable bs
     | r == 2 = unsafeDupablePerformIO $
-      decodeBase64_ dlen decodeB64UrlTable (BS.append bs (BS.replicate 2 0x3d))
+      decodeBase64_ dlen decodeB64UrlTable (BS.append bs "==")
     | r == 3 = unsafeDupablePerformIO $
-      decodeBase64_ dlen decodeB64UrlTable (BS.append bs (BS.replicate 1 0x3d))
+      decodeBase64_ dlen decodeB64UrlTable (BS.append bs "=")
     | otherwise = Left "Base64-encoded bytestring has invalid size"
   where
     (!q, !r) = divMod l 4
@@ -116,9 +116,9 @@ decodeBase64Unpadded bs@(PS !fp !o !l)
     | r == 0 = validateUnpadded $
       decodeBase64_ dlen decodeB64UrlTable bs
     | r == 2 = validateUnpadded $
-      decodeBase64_ dlen decodeB64UrlTable (BS.append bs (BS.replicate 2 0x3d))
+      decodeBase64_ dlen decodeB64UrlTable (BS.append bs "==")
     | r == 3 = validateUnpadded $
-      decodeBase64_ dlen decodeB64UrlTable (BS.append bs (BS.replicate 1 0x3d))
+      decodeBase64_ dlen decodeB64UrlTable (BS.append bs "=")
     | otherwise = Left "Base64-encoded bytestring required to be unpadded"
   where
     (!q, !r) = divMod l 4
@@ -133,7 +133,6 @@ decodeBase64Unpadded bs@(PS !fp !o !l)
         if a == 0x3d || b == 0x3d
         then return $ Left "Base64-encoded bytestring required to be unpadded"
         else io
-
 {-# INLINE decodeBase64Unpadded #-}
 
 -- | Decode a padded Base64url-encoded 'ByteString' value. Input strings are
@@ -146,7 +145,7 @@ decodeBase64Unpadded bs@(PS !fp !o !l)
 -- See: <https://tools.ietf.org/html/rfc4648#section-4 RFC-4648 section 4>
 --
 decodeBase64Padded :: ByteString -> Either Text ByteString
-decodeBase64Padded bs@(PS _ _ !l)
+decodeBase64Padded bs@(PS !_ _ !l)
     | r /= 0 = Left "Base64-encoded bytestring requires padding"
     | otherwise = unsafeDupablePerformIO $
       decodeBase64_ dlen decodeB64UrlTable bs

--- a/test/Base64Tests.hs
+++ b/test/Base64Tests.hs
@@ -195,7 +195,7 @@ paddingTests = testGroup "Padding tests"
             v @=? u
           | otherwise -> do
             step "Unpadded required: padding fails"
-            u @=? Left "Base64-encoded bytestring required to be padded"
+            u @=? Left "Base64-encoded bytestring requires padding"
 
             step "Unpadded required: unpadding succeeds"
             v @=? Right s


### PR DESCRIPTION
Makes sure the concerns of URLsafe or other alphabets don't pollute each other. Also, alignment was messed up from the previous PR. this fixes those regressions. 