### PR TITLE
Add some minor perf improvements

### DIFF
--- a/base64.cabal
+++ b/base64.cabal
@@ -103,7 +103,6 @@ benchmark bench
     , bytestring
     , criterion
     , deepseq
-    , memory
     , random-bytestring
     , text
 

--- a/benchmarks/Base64Bench.hs
+++ b/benchmarks/Base64Bench.hs
@@ -20,8 +20,6 @@ module Main
 import Criterion
 import Criterion.Main
 
-import "memory" Data.ByteArray.Encoding as Mem
-import Data.ByteString
 import "base64-bytestring" Data.ByteString.Base64 as Bos
 import "base64" Data.ByteString.Base64 as B64
 import Data.ByteString.Random (random)
@@ -33,77 +31,59 @@ main =
     [ env bs $ \ ~(bs25,bs100,bs1k,bs10k,bs100k,bs1mm) ->
       bgroup "encode"
       [ bgroup "25"
-        [ bench "memory" $ whnf ctob bs25
-        , bench "base64-bytestring" $ whnf Bos.encode bs25
+        [ bench "base64-bytestring" $ whnf Bos.encode bs25
         , bench "base64" $ whnf B64.encodeBase64' bs25
         ]
       , bgroup "100"
-        [ bench "memory" $ whnf ctob bs100
-        , bench "base64-bytestring" $ whnf Bos.encode bs100
+        [ bench "base64-bytestring" $ whnf Bos.encode bs100
         , bench "base64" $ whnf B64.encodeBase64' bs100
         ]
       , bgroup "1k"
-        [ bench "memory" $ whnf ctob bs1k
-        , bench "base64-bytestring" $ whnf Bos.encode bs1k
+        [ bench "base64-bytestring" $ whnf Bos.encode bs1k
         , bench "base64" $ whnf B64.encodeBase64' bs1k
         ]
       , bgroup "10k"
-        [ bench "memory" $ whnf ctob bs10k
-        , bench "base64-bytestring" $ whnf Bos.encode bs10k
+        [ bench "base64-bytestring" $ whnf Bos.encode bs10k
         , bench "base64" $ whnf B64.encodeBase64' bs10k
         ]
       , bgroup "100k"
-        [ bench "memory" $ whnf ctob bs100k
-        , bench "base64-bytestring" $ whnf Bos.encode bs100k
+        [ bench "base64-bytestring" $ whnf Bos.encode bs100k
         , bench "base64" $ whnf B64.encodeBase64' bs100k
         ]
       , bgroup "1mm"
-        [ bench "memory" $ whnf ctob bs1mm
-        , bench "base64-bytestring" $ whnf Bos.encode bs1mm
+        [ bench "base64-bytestring" $ whnf Bos.encode bs1mm
         , bench "base64" $ whnf B64.encodeBase64' bs1mm
         ]
       ]
     , env bs' $ \ ~(bs25,bs100,bs1k,bs10k,bs100k,bs1mm) ->
       bgroup "decode"
       [ bgroup "25"
-        [ bench "memory" $ whnf btoc bs25
-        , bench "base64-bytestring" $ whnf Bos.decode bs25
+        [ bench "base64-bytestring" $ whnf Bos.decode bs25
         , bench "base64" $ whnf B64.decodeBase64 bs25
         ]
       , bgroup "100"
-        [ bench "memory" $ whnf btoc bs100
-        , bench "base64-bytestring" $ whnf Bos.decode bs100
+        [ bench "base64-bytestring" $ whnf Bos.decode bs100
         , bench "base64" $ whnf B64.decodeBase64 bs100
         ]
       , bgroup "1k"
-        [ bench "memory" $ whnf btoc bs1k
-        , bench "base64-bytestring" $ whnf Bos.decode bs1k
+        [ bench "base64-bytestring" $ whnf Bos.decode bs1k
         , bench "base64" $ whnf B64.decodeBase64 bs1k
         ]
       , bgroup "10k"
-        [ bench "memory" $ whnf btoc bs10k
-        , bench "base64-bytestring" $ whnf Bos.decode bs10k
+        [ bench "base64-bytestring" $ whnf Bos.decode bs10k
         , bench "base64" $ whnf B64.decodeBase64 bs10k
         ]
       , bgroup "100k"
-        [ bench "memory" $ whnf btoc bs100k
-        , bench "base64-bytestring" $ whnf Bos.decode bs100k
+        [ bench "base64-bytestring" $ whnf Bos.decode bs100k
         , bench "base64" $ whnf B64.decodeBase64 bs100k
         ]
       , bgroup "1mm"
-        [ bench "memory" $ whnf btoc bs1mm
-        , bench "base64-bytestring" $ whnf Bos.decode bs1mm
+        [ bench "base64-bytestring" $ whnf Bos.decode bs1mm
         , bench "base64" $ whnf B64.decodeBase64 bs1mm
         ]
       ]
     ]
   where
-    ctob :: ByteString -> ByteString
-    ctob = Mem.convertToBase Mem.Base64
-
-    btoc :: ByteString -> Either String ByteString
-    btoc = Mem.convertFromBase Mem.Base64
-
     bs = do
       a <- random 25
       b <- random 100

--- a/src/Data/ByteString/Base64.hs
+++ b/src/Data/ByteString/Base64.hs
@@ -56,6 +56,7 @@ encodeBase64' = encodeBase64_ base64Table
 --
 decodeBase64 :: ByteString -> Either Text ByteString
 decodeBase64 bs@(PS _ _ l)
+    | l == 0 = Right bs
     | r == 1 = Left "Base64-encoded bytestring has invalid size"
     | r /= 0 = Left "Base64-encoded bytestring requires padding"
     | otherwise = unsafeDupablePerformIO $ decodeBase64_ dlen decodeB64Table bs

--- a/src/Data/ByteString/Base64.hs
+++ b/src/Data/ByteString/Base64.hs
@@ -56,11 +56,13 @@ encodeBase64' = encodeBase64_ base64Table
 --
 decodeBase64 :: ByteString -> Either Text ByteString
 decodeBase64 bs@(PS _ _ !l)
+    | l == 0 = Right bs
     | r == 1 = Left "Base64-encoded bytestring has invalid size"
     | r /= 0 = Left "Base64-encoded bytestring requires padding"
     | otherwise = unsafeDupablePerformIO $ decodeBase64_ dlen decodeB64Table bs
   where
-    (!q, !r) = divMod l 4
+    !q = l `quot` 4
+    !r = l `rem` 4
     !dlen = q * 3
 {-# INLINE decodeBase64 #-}
 

--- a/src/Data/ByteString/Base64.hs
+++ b/src/Data/ByteString/Base64.hs
@@ -55,15 +55,14 @@ encodeBase64' = encodeBase64_ base64Table
 -- See: <https://tools.ietf.org/html/rfc4648#section-4 RFC-4648 section 4>
 --
 decodeBase64 :: ByteString -> Either Text ByteString
-decodeBase64 bs@(PS _ _ !l)
-    | l == 0 = Right bs
+decodeBase64 bs@(PS _ _ l)
     | r == 1 = Left "Base64-encoded bytestring has invalid size"
     | r /= 0 = Left "Base64-encoded bytestring requires padding"
     | otherwise = unsafeDupablePerformIO $ decodeBase64_ dlen decodeB64Table bs
   where
-    !q = l `quot` 4
-    !r = l `rem` 4
-    !dlen = q * 3
+    q = l `quot` 4
+    r = l `rem` 4
+    dlen = q * 3
 {-# INLINE decodeBase64 #-}
 
 -- | Leniently decode an unpadded Base64-encoded 'ByteString' value. This function

--- a/src/Data/ByteString/Base64/Internal/Head.hs
+++ b/src/Data/ByteString/Base64/Internal/Head.hs
@@ -59,7 +59,6 @@ encodeBase64_ (EncodingTable !aptr !efp) (PS !sfp !soff !slen) =
             (loopTail dfp aptr dptr (castPtr end))
   where
     !dlen = 4 * ((slen + 2) `div` 3)
-{-# inline encodeBase64_ #-}
 
 encodeBase64Nopad_ :: EncodingTable -> ByteString -> ByteString
 encodeBase64Nopad_ (EncodingTable !aptr !efp) (PS !sfp !soff !slen) =
@@ -77,7 +76,6 @@ encodeBase64Nopad_ (EncodingTable !aptr !efp) (PS !sfp !soff !slen) =
             (loopTailNoPad dfp aptr dptr (castPtr end))
   where
     !dlen = 4 * ((slen + 2) `div` 3)
-{-# inline encodeBase64Nopad_ #-}
 
 -- | The main decode function. Takes a padding flag, a decoding table, and
 -- the input value, producing either an error string on the left, or a
@@ -94,7 +92,6 @@ decodeBase64_
     -> ForeignPtr Word8
     -> ByteString
     -> IO (Either Text ByteString)
-decodeBase64_ _ _ (PS _ _ 0) = return $ Right mempty
 decodeBase64_ !dlen !dtfp (PS !sfp !soff !slen) =
     withForeignPtr dtfp $ \dtable ->
     withForeignPtr sfp $ \sptr -> do
@@ -106,7 +103,6 @@ decodeBase64_ !dlen !dtfp (PS !sfp !soff !slen) =
           dptr
           (plusPtr sptr (soff + slen))
           (decodeTail dfp dtable sptr dptr)
-{-# inline decodeBase64_ #-}
 
 decodeBase64Lenient_ :: ForeignPtr Word8 -> ByteString -> ByteString
 decodeBase64Lenient_ !dtfp (PS !sfp !soff !slen) = unsafeDupablePerformIO $

--- a/src/Data/ByteString/Base64/Internal/Head.hs
+++ b/src/Data/ByteString/Base64/Internal/Head.hs
@@ -44,13 +44,13 @@ import System.IO.Unsafe
 
 
 encodeBase64_ :: EncodingTable -> ByteString -> ByteString
-encodeBase64_ (EncodingTable !aptr !efp) (PS !sfp !soff !slen) =
+encodeBase64_ (EncodingTable aptr efp) (PS sfp soff slen) =
     unsafeDupablePerformIO $ do
       dfp <- mallocPlainForeignPtrBytes dlen
       withForeignPtr dfp $ \dptr ->
         withForeignPtr sfp $ \sptr ->
         withForeignPtr efp $ \eptr -> do
-          let !end = plusPtr sptr (soff + slen)
+          let end = plusPtr sptr (soff + slen)
           innerLoop
             eptr
             (castPtr (plusPtr sptr soff))
@@ -58,7 +58,7 @@ encodeBase64_ (EncodingTable !aptr !efp) (PS !sfp !soff !slen) =
             end
             (loopTail dfp aptr dptr (castPtr end))
   where
-    !dlen = 4 * ((slen + 2) `div` 3)
+    dlen = 4 * ((slen + 2) `div` 3)
 
 encodeBase64Nopad_ :: EncodingTable -> ByteString -> ByteString
 encodeBase64Nopad_ (EncodingTable !aptr !efp) (PS !sfp !soff !slen) =
@@ -92,7 +92,7 @@ decodeBase64_
     -> ForeignPtr Word8
     -> ByteString
     -> IO (Either Text ByteString)
-decodeBase64_ !dlen !dtfp (PS !sfp !soff !slen) =
+decodeBase64_ dlen dtfp (PS sfp soff slen) =
     withForeignPtr dtfp $ \dtable ->
     withForeignPtr sfp $ \sptr -> do
       dfp <- mallocPlainForeignPtrBytes dlen
@@ -102,7 +102,8 @@ decodeBase64_ !dlen !dtfp (PS !sfp !soff !slen) =
           (plusPtr sptr soff)
           dptr
           (plusPtr sptr (soff + slen))
-          (decodeTail dfp dtable sptr dptr)
+          dfp
+
 
 decodeBase64Lenient_ :: ForeignPtr Word8 -> ByteString -> ByteString
 decodeBase64Lenient_ !dtfp (PS !sfp !soff !slen) = unsafeDupablePerformIO $

--- a/src/Data/ByteString/Base64/Internal/Head.hs
+++ b/src/Data/ByteString/Base64/Internal/Head.hs
@@ -104,7 +104,6 @@ decodeBase64_ dlen dtfp (PS sfp soff slen) =
           (plusPtr sptr (soff + slen))
           dfp
 
-
 decodeBase64Lenient_ :: ForeignPtr Word8 -> ByteString -> ByteString
 decodeBase64Lenient_ !dtfp (PS !sfp !soff !slen) = unsafeDupablePerformIO $
     withForeignPtr dtfp $ \dtable ->

--- a/src/Data/ByteString/Base64/Internal/Tail.hs
+++ b/src/Data/ByteString/Base64/Internal/Tail.hs
@@ -20,8 +20,6 @@ module Data.ByteString.Base64.Internal.Tail
 import Data.Bits
 import Data.ByteString.Internal
 import Data.ByteString.Base64.Internal.Utils
-import Data.Text (Text)
-import qualified Data.Text as T
 
 import Foreign.ForeignPtr
 import Foreign.Ptr

--- a/src/Data/ByteString/Base64/Internal/Tail.hs
+++ b/src/Data/ByteString/Base64/Internal/Tail.hs
@@ -15,7 +15,6 @@
 module Data.ByteString.Base64.Internal.Tail
 ( loopTail
 , loopTailNoPad
-, decodeTail
 ) where
 
 import Data.Bits
@@ -85,91 +84,28 @@ loopTailNoPad
     -> Ptr Word8
     -> IO ByteString
 loopTailNoPad !dfp (Ptr !alpha) !dptr !end !src !dst
-      | src == end = return (PS dfp 0 (minusPtr dst dptr))
-      | plusPtr src 1 == end = do
-        !x <- peek @Word8 src
+    | src == end = return (PS dfp 0 (minusPtr dst dptr))
+    | plusPtr src 1 == end = do
+      !x <- peek @Word8 src
 
-        let !a = shiftR (x .&. 0xfc) 2
-            !b = shiftL (x .&. 0x03) 4
+      let !a = shiftR (x .&. 0xfc) 2
+          !b = shiftL (x .&. 0x03) 4
 
-        poke @Word8 dst (aix a alpha)
-        poke @Word8 (plusPtr dst 1) (aix b alpha)
-        return (PS dfp 0 (2 + (minusPtr dst dptr)))
-      | otherwise = do
-        !x <- peek @Word8 src
-        !y <- peek @Word8 (plusPtr src 1)
+      poke @Word8 dst (aix a alpha)
+      poke @Word8 (plusPtr dst 1) (aix b alpha)
+      return (PS dfp 0 (2 + (minusPtr dst dptr)))
+    | otherwise = do
+      !x <- peek @Word8 src
+      !y <- peek @Word8 (plusPtr src 1)
 
-        let !a = shiftR (x .&. 0xfc) 2
-            !b = shiftL (x .&. 0x03) 4
+      let !a = shiftR (x .&. 0xfc) 2
+          !b = shiftL (x .&. 0x03) 4
 
-        let !c = shiftR (y .&. 0xf0) 4 .|. b
-            !d = shiftL (y .&. 0x0f) 2
+      let !c = shiftR (y .&. 0xf0) 4 .|. b
+          !d = shiftL (y .&. 0x0f) 2
 
-        poke @Word8 dst (aix a alpha)
-        poke @Word8 (plusPtr dst 1) (aix c alpha)
-        poke @Word8 (plusPtr dst 2) (aix d alpha)
-        return (PS dfp 0 (3 + (minusPtr dst dptr)))
+      poke @Word8 dst (aix a alpha)
+      poke @Word8 (plusPtr dst 1) (aix c alpha)
+      poke @Word8 (plusPtr dst 2) (aix d alpha)
+      return (PS dfp 0 (3 + (minusPtr dst dptr)))
 {-# inline loopTailNoPad #-}
-
-decodeTail
-    :: ForeignPtr Word8
-      -- ^ dst bytestring foreign ptr
-    -> Ptr Word8
-      -- ^ decode table
-    -> Ptr Word8
-      -- ^ original decode static pointer
-    -> Ptr Word8
-      -- ^ original source pointer (for offset calculation)
-    -> Ptr Word8
-      -- ^ dst ptr
-    -> Ptr Word8
-      -- ^ src ptr
-    -> IO (Either Text ByteString)
-decodeTail !dfp !dtable !sptr !dptr !dst !src = do
-    !w <- peek @Word8 src
-    !x <- peek @Word8 (plusPtr src 1)
-    !y <- peek @Word8 (plusPtr src 2)
-    !z <- peek @Word8 (plusPtr src 3)
-
-    !a <- w32 <$> peekByteOff @Word8 dtable (fromIntegral w)
-    !b <- w32 <$> peekByteOff @Word8 dtable (fromIntegral x)
-    !c <- w32 <$> peekByteOff @Word8 dtable (fromIntegral y)
-    !d <- w32 <$> peekByteOff @Word8 dtable (fromIntegral z)
-
-    if
-      | a == 0xff -> err src
-      | b == 0xff -> err (plusPtr src 1)
-      | c == 0xff -> err (plusPtr src 2)
-      | d == 0xff -> err (plusPtr src 3)
-      | a == 0x63 -> padErr src
-      | b == 0x63 -> padErr (plusPtr src 1)
-      | c == 0x63, d /= 0x63 -> padErr (plusPtr src 3)
-      | otherwise -> do
-
-        let !ww = (unsafeShiftL a 18)
-              .|. (unsafeShiftL b 12)
-              .|. (unsafeShiftL c 6)
-              .|. d
-
-        if
-          | c == 0x63, d == 0x63 -> do
-            poke @Word8 dst (fromIntegral (unsafeShiftR ww 16))
-            return $ Right (PS dfp 0 (1 + (minusPtr dst dptr)))
-          | d == 0x63 -> do
-            poke @Word8 dst (fromIntegral (unsafeShiftR ww 16))
-            poke @Word8 (plusPtr dst 1) (fromIntegral (unsafeShiftR ww 8))
-            return $ Right (PS dfp 0 (2 + (minusPtr dst dptr)))
-          | otherwise -> do
-            poke @Word8 dst (fromIntegral (unsafeShiftR ww 16))
-            poke @Word8 (plusPtr dst 1) (fromIntegral (unsafeShiftR ww 8))
-            poke @Word8 (plusPtr dst 2) (fromIntegral ww)
-            return $ Right (PS dfp 0 (3 + (minusPtr dst dptr)))
-  where
-    err p = return . Left . T.pack
-      $ "invalid character at offset: "
-      ++ show (p `minusPtr` sptr)
-
-    padErr p =  return . Left . T.pack
-      $ "invalid padding at offset: "
-      ++ show (p `minusPtr` sptr)
-{-# inline decodeTail #-}

--- a/src/Data/ByteString/Base64/Internal/W32/Loop.hs
+++ b/src/Data/ByteString/Base64/Internal/W32/Loop.hs
@@ -72,7 +72,7 @@ decodeLoop
         -- ^ dst pointer
     -> Ptr Word8
         -- ^ end of src ptr
-    -> (Ptr Word8 -> Ptr Word8 -> IO (Either Text ByteString))
+    -> ForeignPtr Word8
     -> IO (Either Text ByteString)
 decodeLoop = W16.decodeLoop
 {-# INLINE decodeLoop #-}

--- a/src/Data/ByteString/Base64/Internal/W64/Loop.hs
+++ b/src/Data/ByteString/Base64/Internal/W64/Loop.hs
@@ -80,7 +80,7 @@ decodeLoop
         -- ^ dst pointer
     -> Ptr Word8
         -- ^ end of src ptr
-    -> (Ptr Word8 -> Ptr Word8 -> IO (Either Text ByteString))
+    -> ForeignPtr Word8
         -- ^ dst foreign ptr (for consing bs)
     -> IO (Either Text ByteString)
 decodeLoop = W16.decodeLoop

--- a/src/Data/ByteString/Base64/URL.hs
+++ b/src/Data/ByteString/Base64/URL.hs
@@ -64,16 +64,15 @@ encodeBase64' = encodeBase64_ base64UrlTable
 -- See: <https://tools.ietf.org/html/rfc4648#section-4 RFC-4648 section 4>
 --
 decodeBase64 :: ByteString -> Either Text ByteString
-decodeBase64 bs@(PS _ _ !l)
-    | l == 0 = Right bs
+decodeBase64 bs@(PS _ _ l)
     | r == 0 = unsafeDupablePerformIO $ decodeBase64_ dlen decodeB64UrlTable bs
     | r == 2 = unsafeDupablePerformIO $ decodeBase64_ dlen decodeB64UrlTable (BS.append bs "==")
     | r == 3 = validateLastPad bs $ decodeBase64_ dlen decodeB64UrlTable (BS.append bs "=")
     | otherwise = Left "Base64-encoded bytestring has invalid size"
   where
-    !q = l `quot` 4
-    !r = l `rem` 4
-    !dlen = q * 3
+    q = l `quot` 4
+    r = l `rem` 4
+    dlen = q * 3
 {-# INLINE decodeBase64 #-}
 
 -- | Encode a 'ByteString' value as Base64url 'Text' without padding. Note that for Base64url,
@@ -105,16 +104,15 @@ encodeBase64Unpadded' = encodeBase64Nopad_ base64UrlTable
 -- See: <https://tools.ietf.org/html/rfc4648#section-4 RFC-4648 section 4>
 --
 decodeBase64Unpadded :: ByteString -> Either Text ByteString
-decodeBase64Unpadded bs@(PS _ _ !l)
-    | l == 0 = Right bs
+decodeBase64Unpadded bs@(PS _ _ l)
     | r == 0 = validateLastPad bs $ decodeBase64_ dlen decodeB64UrlTable bs
     | r == 2 = validateLastPad bs $ decodeBase64_ dlen decodeB64UrlTable (BS.append bs "==")
     | r == 3 = validateLastPad bs $ decodeBase64_ dlen decodeB64UrlTable (BS.append bs "=")
     | otherwise = Left "Base64-encoded bytestring has invalid size"
   where
-    !q = l `quot` 4
-    !r = l `rem` 4
-    !dlen = q * 3
+    q = l `quot` 4
+    r = l `rem` 4
+    dlen = q * 3
 {-# INLINE decodeBase64Unpadded #-}
 
 -- | Decode a padded Base64url-encoded 'ByteString' value. Input strings are
@@ -127,15 +125,14 @@ decodeBase64Unpadded bs@(PS _ _ !l)
 -- See: <https://tools.ietf.org/html/rfc4648#section-4 RFC-4648 section 4>
 --
 decodeBase64Padded :: ByteString -> Either Text ByteString
-decodeBase64Padded bs@(PS !_ _ !l)
-    | l == 0 = Right bs
+decodeBase64Padded bs@(PS _ _ l)
     | r == 1 = Left "Base64-encoded bytestring has invalid size"
     | r /= 0 = Left "Base64-encoded bytestring requires padding"
     | otherwise = unsafeDupablePerformIO $ decodeBase64_ dlen decodeB64UrlTable bs
   where
-    !q = l `quot` 4
-    !r = l `rem` 4
-    !dlen = q * 3
+    q = l `quot` 4
+    r = l `rem` 4
+    dlen = q * 3
 {-# INLINE decodeBase64Padded #-}
 
 -- | Leniently decode an unpadded Base64url-encoded 'ByteString'. This function

--- a/src/Data/ByteString/Base64/URL.hs
+++ b/src/Data/ByteString/Base64/URL.hs
@@ -71,7 +71,8 @@ decodeBase64 bs@(PS _ _ !l)
     | r == 3 = validateLastPad bs $ decodeBase64_ dlen decodeB64UrlTable (BS.append bs "=")
     | otherwise = Left "Base64-encoded bytestring has invalid size"
   where
-    (!q, !r) = divMod l 4
+    !q = l `quot` 4
+    !r = l `rem` 4
     !dlen = q * 3
 {-# INLINE decodeBase64 #-}
 
@@ -111,7 +112,8 @@ decodeBase64Unpadded bs@(PS _ _ !l)
     | r == 3 = validateLastPad bs $ decodeBase64_ dlen decodeB64UrlTable (BS.append bs "=")
     | otherwise = Left "Base64-encoded bytestring has invalid size"
   where
-    (!q, !r) = divMod l 4
+    !q = l `quot` 4
+    !r = l `rem` 4
     !dlen = q * 3
 {-# INLINE decodeBase64Unpadded #-}
 
@@ -131,7 +133,8 @@ decodeBase64Padded bs@(PS !_ _ !l)
     | r /= 0 = Left "Base64-encoded bytestring requires padding"
     | otherwise = unsafeDupablePerformIO $ decodeBase64_ dlen decodeB64UrlTable bs
   where
-    (!q, !r) = divMod l 4
+    !q = l `quot` 4
+    !r = l `rem` 4
     !dlen = q * 3
 {-# INLINE decodeBase64Padded #-}
 

--- a/src/Data/ByteString/Base64/URL.hs
+++ b/src/Data/ByteString/Base64/URL.hs
@@ -65,6 +65,7 @@ encodeBase64' = encodeBase64_ base64UrlTable
 --
 decodeBase64 :: ByteString -> Either Text ByteString
 decodeBase64 bs@(PS _ _ l)
+    | l == 0 = Right bs
     | r == 0 = unsafeDupablePerformIO $ decodeBase64_ dlen decodeB64UrlTable bs
     | r == 2 = unsafeDupablePerformIO $ decodeBase64_ dlen decodeB64UrlTable (BS.append bs "==")
     | r == 3 = validateLastPad bs $ decodeBase64_ dlen decodeB64UrlTable (BS.append bs "=")
@@ -105,6 +106,7 @@ encodeBase64Unpadded' = encodeBase64Nopad_ base64UrlTable
 --
 decodeBase64Unpadded :: ByteString -> Either Text ByteString
 decodeBase64Unpadded bs@(PS _ _ l)
+    | l == 0 = Right bs
     | r == 0 = validateLastPad bs $ decodeBase64_ dlen decodeB64UrlTable bs
     | r == 2 = validateLastPad bs $ decodeBase64_ dlen decodeB64UrlTable (BS.append bs "==")
     | r == 3 = validateLastPad bs $ decodeBase64_ dlen decodeB64UrlTable (BS.append bs "=")
@@ -126,6 +128,7 @@ decodeBase64Unpadded bs@(PS _ _ l)
 --
 decodeBase64Padded :: ByteString -> Either Text ByteString
 decodeBase64Padded bs@(PS _ _ l)
+    | l == 0 = Right bs
     | r == 1 = Left "Base64-encoded bytestring has invalid size"
     | r /= 0 = Left "Base64-encoded bytestring requires padding"
     | otherwise = unsafeDupablePerformIO $ decodeBase64_ dlen decodeB64UrlTable bs

--- a/test/Internal.hs
+++ b/test/Internal.hs
@@ -41,7 +41,7 @@ import "base64" Data.Text.Short.Encoding.Base64 as TS64
 import "base64" Data.Text.Short.Encoding.Base64.URL as TS64U
 
 import Test.QuickCheck hiding (label)
-import Test.QuickCheck.Instances
+import Test.QuickCheck.Instances ()
 
 -- ------------------------------------------------------------------ --
 -- Test Harnesses


### PR DESCRIPTION
- Use `quot` and `rem` instead of `divMod` (separately, they create nicer ASM). 
- Make sure `l == 0` calculations are consistently at the head (removes a redund. branch from decode). 
- Spurious inlines hurt alignment (removed)
- Spurious bangpatterns do the same. 
- Fold finalizer into `decode` loop so we don't have redundant code. 