### PR TITLE
Support text 2

### DIFF
--- a/base64.cabal
+++ b/base64.cabal
@@ -57,7 +57,7 @@ library
       base           >=4.14     && <4.17
     , bytestring     >=0.10     && <0.12
     , deepseq        >=1.4.3.0  && <1.5
-    , text           ^>=1.2
+    , text           >=1.2 && <1.3 || >=2.0 && <2.1
     , text-short     ^>=0.1
 
   hs-source-dirs:   src


### PR DESCRIPTION
base64 doesn't seem to be affected by breaking changes in the text 2 package.