### PR TITLE
[WIP] SIMD acceleration

### DIFF
--- a/base64.cabal
+++ b/base64.cabal
@@ -25,6 +25,11 @@ source-repository head
   type:     git
   location: https://github.com/emilypi/base64.git
 
+flag simd
+  description: use libbase64 simd library
+  default: True
+  manual: True
+
 library
   exposed-modules:
     Data.Base64.Types
@@ -61,7 +66,13 @@ library
 
   hs-source-dirs:   src
   default-language: Haskell2010
-  ghc-options:      -Wall
+  ghc-options:      -Wall -O2
+
+  if flag(simd)
+    build-depends:
+      libbase64-bindings
+    cpp-options:
+      -DSIMD
 
 test-suite base64-tests
   default-language: Haskell2010
@@ -99,4 +110,4 @@ benchmark bench
     , random-bytestring
     , text               >=2.0
 
-  ghc-options:      -Wall -rtsopts
+  ghc-options:      -Wall -O2 -rtsopts

--- a/default.nix
+++ b/default.nix
@@ -1,41 +1,47 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "default", doBenchmark ? false }:
+let
+  hs-libbase64 = import (builtins.fetchTarball {
+    url = "https://github.com/chessai/hs-libbase64-bindings/archive/e8a5194742f41ce4109b05098a2859e8052ad1c1.tar.gz";
+    sha256 = "1xqfjqb1ghh8idnindc6gfr62d78m5cc6jpbhv1hja8lkdrl8qf8";
+  }) {};
+in
+{
+  compiler ? "ghc944",
+  pkgs ? import <nixpkgs> {
+    config = {
+      allowBroken = false;
+      allowUnfree = false;
+    };
+
+    overlays = [ ];
+      /*(self: super: {
+        # not in nixpkgs yet
+        inherit (hs-libbase64) libbase64;
+
+        "haskell.packages.${compiler}" = haskell.packages.${compiler}.override {
+          overrides = hself: hsuper: {
+            inherit (hs-libbase64) libbase64-bindings;
+          };
+        };
+      })*/
+  },
+  returnShellEnv ? false,
+}:
 
 let
-
-  inherit (nixpkgs) pkgs;
-
-  f = { mkDerivation, base, base64-bytestring, bytestring
-      , criterion, deepseq, ghc-byteorder, QuickCheck, random-bytestring
-      , stdenv, tasty, tasty-hunit, tasty-quickcheck, text, text-short
-      }:
-      mkDerivation {
-        pname = "base64";
-        version = "0.4.2.2";
-        src = ./.;
-        libraryHaskellDepends = [
-          base bytestring deepseq ghc-byteorder text text-short
-        ];
-        testHaskellDepends = [
-          base base64-bytestring bytestring QuickCheck random-bytestring
-          tasty tasty-hunit tasty-quickcheck text text-short
-        ];
-        benchmarkHaskellDepends = [
-          base base64-bytestring bytestring criterion deepseq
-          random-bytestring text
-        ];
-        homepage = "https://github.com/emilypi/base64";
-        description = "Fast RFC 4648-compliant Base64 encoding";
-        license = stdenv.lib.licenses.bsd3;
-      };
-
-  haskellPackages = if compiler == "default"
-                       then pkgs.haskellPackages
-                       else pkgs.haskell.packages.${compiler};
-
-  variant = if doBenchmark then pkgs.haskell.lib.doBenchmark else pkgs.lib.id;
-
-  drv = variant (haskellPackages.callPackage f {});
-
+  nix-gitignore = import (pkgs.fetchFromGitHub {
+    owner = "hercules-ci";
+    repo = "gitignore";
+    rev = "9e80c4d83026fa6548bc53b1a6fab8549a6991f6";
+    sha256 = "04n9chlpbifgc5pa3zx6ff3rji9am6msrbn1z3x1iinjz2xjfp4p";
+  }) {};
 in
+pkgs.haskell.packages.${compiler}.developPackage {
+  name = "base64";
+  root = nix-gitignore.gitignoreSource ./.;
 
-  if pkgs.lib.inNixShell then drv.env else drv
+  overrides = self: super: {
+    inherit (hs-libbase64) libbase64-bindings;
+  };
+
+  inherit returnShellEnv;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+import ./default.nix { returnShellEnv = true; }


### PR DESCRIPTION
Adds SIMD acceleration via [libbase64](https://github.com/aklomp/base64).
Depends on the yet-to-be-released haskell bindings library, [libbase64-bindings](https://github.com/chessai/hs-libbase64-bindings).

Adds a cabal flag, `simd`, to enable SIMD. Enabled by default.

## Benchmarks
I'm running this on a relatively quiet box, with NixOS/Linux installed.

CPU Info of the machine where I'm running these benchmarks:
```
❯ cat /proc/cpuinfo
...truncated...
processor	: 7
vendor_id	: GenuineIntel
cpu family	: 6
model		: 158
model name	: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
stepping	: 9
microcode	: 0x48
cpu MHz        : 3473.454
cache size	: 6144 KB
...truncated...

❯ cat /proc/cpuinfo | egrep -o '(avx|avx2|ssse3|sse4_1|sse4_2)' | sort -u
avx
avx2
sse4_1
sse4_2
ssse3
```

If you download the [current criterion benchmark reports](https://gist.github.com/chessai/5d34c85453a9ad60b214a4a7aab31524) you can view them in your browser.

For small ByteStrings, there is a significant penalty, so we should probably guard which encoding method is done based on the size of the ByteString. (**EDIT**: From experiments I determined that 1000 bytes is a safe threshold for encoding fallback, and 250 bytes for decoding. This PR implements the thresholds for `encodeBase64_` and `decodeBase64_`, currently.)

### Speedup summary tables (does not include unaffected under-threshold ByteStrings)

`encodeBase64_` Speedups:
| Size | vs old `base64` | vs `base64-bytestring` |
| ------------- | ----------------------|----------------------------------|
| 1k | 1.17x  | 3.07x |
| 10k  | 3.45x  | 12.15x |
| 100k  | 4.53x  | 11.71x |
| 100mm  | 4.69x  | 14.21x |

`decodeBase64_` Speedups:
| Size | vs old `base64` | vs `base64-bytestring` |
| ------------- | ----------------------|----------------------------------|
| 1k | 4.06x  | 5.01x|
| 10k  | 11.29x | 12.28x |
| 100k  | 15.63x  | 16.44x |
| 100mm  | 13.87x | 19.48x |

![with_simd](https://user-images.githubusercontent.com/18648043/233258033-c9ff2a15-4883-4c05-8fc9-4dcf2efe3a67.png)