### PR TITLE
Bump bounds

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        ghc: ['8.10', '9.0', '9.2', '9.4', '9.6']
+        ghc: ['8.10', '9.0', '9.2', '9.4', '9.6', '9.8']
         include:
         - os: macOS-latest
           ghc: 'latest'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle

--- a/base64.cabal
+++ b/base64.cabal
@@ -19,7 +19,7 @@ extra-doc-files:
   CHANGELOG.md
   README.md
 
-tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.5 || ==9.4.5 || ==9.6.1
+tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.5 || ==9.4.7 || ==9.6.3 || ==9.8.1
 
 source-repository head
   type:     git

--- a/base64.cabal
+++ b/base64.cabal
@@ -53,10 +53,10 @@ library
     Data.ByteString.Base64.Internal.W64.Loop
 
   build-depends:
-      base           >=4.14     && <4.19
-    , bytestring     ^>=0.11
-    , deepseq        >=1.4.4.0  && <1.5
-    , text           ^>=2.0
+      base           >=4.14     && <4.20
+    , bytestring     >=0.11
+    , deepseq        >=1.4.4.0  && <1.6
+    , text           >=2.0
     , text-short     ^>=0.1
 
   hs-source-dirs:   src
@@ -70,10 +70,10 @@ test-suite base64-tests
   other-modules:    Internal
   main-is:          Main.hs
   build-depends:
-      base               >=4.14 && <4.19
+      base               >=4.14 && <4.20
     , base64
     , base64-bytestring
-    , bytestring         ^>=0.11
+    , bytestring         >=0.11
     , QuickCheck
     , random-bytestring
     , tasty
@@ -90,10 +90,10 @@ benchmark bench
   hs-source-dirs:   benchmarks
   main-is:          Base64Bench.hs
   build-depends:
-      base               >=4.14 && <4.19
+      base               >=4.14 && <4.20
     , base64
     , base64-bytestring
-    , bytestring         >=0.11
+    , bytestring         >=0.12
     , criterion
     , deepseq
     , random-bytestring


### PR DESCRIPTION
`cabal outdated` guided me on this one, where the following dependencies are updated:

* base, to accept 4.19
* bytestring, to accept 0.11
* deepseq, to accept 1.5
* text, to accept 2.1

@emilypi 