### PR TITLE
Bump to haskell-actions/setup

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -26,7 +26,7 @@ jobs:
       if: runner.os == 'Linux' && (matrix.ghc == '8.0' || matrix.ghc == '8.2')
       run: |
         sudo apt-get install libncurses5 libtinfo5
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-cabal
       with:
         ghc-version: ${{ matrix.ghc }}
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       id: setup-haskell-cabal
       with:
         ghc-version: 'latest'


### PR DESCRIPTION
Following the advice of the haskell/actions/setup is deprecated notice:

```
Warning: As of 2023-09-09, haskell/action/setup is no longer maintained,
please switch to haskell-actions/setup (note: dash for slash).
***************************************************************************
**                                                                       **
**              This action is DEPRECATED.                               **
**                                                                       **
**              Please use haskell-actions/setup instead.                **
**                                                                       **
**              (Note the dash instead of the slash.)                    **
**                                                                       **
***************************************************************************
```