### PR TITLE
Bump for ghc 9.10.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        ghc: ['8.10', '9.0', '9.2', '9.4', '9.6', '9.8']
+        ghc: ['8.10', '9.0', '9.2', '9.4', '9.6', '9.8', '9.10']
         include:
         - os: macOS-latest
           ghc: 'latest'

--- a/base64.cabal
+++ b/base64.cabal
@@ -20,7 +20,7 @@ extra-doc-files:
   README.md
   MIGRATION-1.0.md
 
-tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.5 || ==9.4.7 || ==9.6.3 || ==9.8.1
+tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.5 || ==9.8.2 || ==9.10.1
 
 source-repository head
   type:     git

--- a/base64.cabal
+++ b/base64.cabal
@@ -54,7 +54,7 @@ library
     Data.ByteString.Base64.Internal.W64.Loop
 
   build-depends:
-      base           >=4.14     && <4.20
+      base           >=4.14     && <4.22
     , bytestring     >=0.11     && <0.13
     , deepseq        >=1.4.4.0  && <1.6
     , text           >=2.0      && <2.3
@@ -71,7 +71,7 @@ test-suite base64-tests
   other-modules:    Internal
   main-is:          Main.hs
   build-depends:
-      base               >=4.14 && <4.20
+      base               >=4.14 && <4.22
     , base64
     , base64-bytestring
     , bytestring         >=0.11
@@ -91,7 +91,7 @@ benchmark bench
   hs-source-dirs:   benchmarks
   main-is:          Base64Bench.hs
   build-depends:
-      base               >=4.14 && <4.20
+      base               >=4.14 && <4.22
     , base64
     , base64-bytestring
     , bytestring         >=0.11


### PR DESCRIPTION
Bump tested-with and base upper bounds for `ghc-9.10.1`.