### PR TITLE
Cabal Update 

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        ghc: ['8.10', '9.0', '9.2', '9.4', '9.6', '9.8', '9.10']
+        ghc: ['9.6', '9.8', '9.10', '9.12', '9.14']
         include:
         - os: macOS-latest
           ghc: 'latest'
@@ -80,20 +80,3 @@ jobs:
     - name: Test
       run: cabal test --ghc-options='-fcheck-prim-bounds -fno-ignore-asserts'
 
-  i386:
-    needs: build
-    runs-on: ubuntu-latest
-    container:
-      image: i386/ubuntu:bionic
-    steps:
-    - name: Install
-      run: |
-        apt-get update -y
-        apt-get install -y autoconf build-essential zlib1g-dev libgmp-dev curl libncurses5 libtinfo5 libncurses5-dev libtinfo-dev
-        curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 sh
-    - uses: actions/checkout@v1
-    - name: Test
-      run: |
-        source ~/.ghcup/env
-        cabal update
-        cabal test

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -21,7 +21,7 @@ jobs:
         - os: macOS-latest
           ghc: 'latest'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install libncurses5 and libtinfo
       if: runner.os == 'Linux' && (matrix.ghc == '8.0' || matrix.ghc == '8.2')
       run: |
@@ -32,7 +32,7 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
     - name: Update cabal package database
       run: cabal update
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       name: Cache cabal stuff
       with:
         path: |
@@ -70,7 +70,7 @@ jobs:
         ghc-version: 'latest'
     - name: Update cabal package database
       run: cabal update
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       name: Cache cabal stuff
       with:
         path: |

--- a/base64.cabal
+++ b/base64.cabal
@@ -12,7 +12,7 @@ license-file:    LICENSE
 author:          Emily Pillmore
 maintainer:      Emily Pillmore <emilypi@cohomolo.gy>
                , Sofia-m-a <https://github.com/sofia-m-a>
-copyright:       (c) 2019-2023 Emily Pillmore
+copyright:       (c) 2019-2026 Emily Pillmore
 category:        Data
 build-type:      Simple
 extra-doc-files:
@@ -20,7 +20,7 @@ extra-doc-files:
   README.md
   MIGRATION-1.0.md
 
-tested-with:     GHC ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.8 || ==9.6.5 || ==9.8.2 || ==9.10.1
+tested-with:     GHC ==9.6.7 || ==9.8.4 || ==9.10.3 || ==9.14.1
 
 source-repository head
   type:     git
@@ -54,7 +54,7 @@ library
     Data.ByteString.Base64.Internal.W64.Loop
 
   build-depends:
-      base           >=4.14     && <4.22
+      base           >=4.18     && <4.23
     , bytestring     >=0.11     && <0.13
     , deepseq        >=1.4.4.0  && <1.6
     , text           >=2.0      && <2.3
@@ -71,7 +71,7 @@ test-suite base64-tests
   other-modules:    Internal
   main-is:          Main.hs
   build-depends:
-      base               >=4.14 && <4.22
+      base               >=4.18 && <4.23
     , base64
     , base64-bytestring
     , bytestring         >=0.11
@@ -91,7 +91,7 @@ benchmark bench
   hs-source-dirs:   benchmarks
   main-is:          Base64Bench.hs
   build-depends:
-      base               >=4.14 && <4.22
+      base               >=4.18 && <4.23
     , base64
     , base64-bytestring
     , bytestring         >=0.11


### PR DESCRIPTION
- Update copyright 
- Bump ghc bounds for 9.14
- Drop support for i386

Addresses #66 